### PR TITLE
Feature/file storage: DiskInterface and Index

### DIFF
--- a/src/component/database.rs
+++ b/src/component/database.rs
@@ -1,6 +1,6 @@
 use crate::component::table::Table;
+use crate::storage::diskinterface::DiskError;
 use crate::storage::file::File;
-use crate::storage::file::FileError;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -16,7 +16,7 @@ pub struct Database {
 
 #[derive(Debug)]
 pub enum DatabaseError {
-    CausedByFile(FileError),
+    CausedByFile(DiskError),
 }
 
 impl fmt::Display for DatabaseError {

--- a/src/component/database.rs
+++ b/src/component/database.rs
@@ -1,6 +1,5 @@
 use crate::component::table::Table;
-use crate::storage::diskinterface::DiskError;
-use crate::storage::file::File;
+use crate::storage::diskinterface::{DiskError, DiskInterface};
 use std::collections::HashMap;
 use std::fmt;
 
@@ -45,7 +44,8 @@ impl Database {
     pub fn load_db(username: &str, db_name: &str) -> Result<Database, DatabaseError> {
         let mut db = Database::new(db_name);
         db.is_dirty = false;
-        let metas = File::load_tables_meta(username, db_name, None).map_err(|e| DatabaseError::CausedByFile(e))?;
+        let metas =
+            DiskInterface::load_tables_meta(username, db_name, None).map_err(|e| DatabaseError::CausedByFile(e))?;
         for meta in metas {
             let name = (&meta.name).to_string();
             let mut table = Table::new(&name);

--- a/src/component/table.rs
+++ b/src/component/table.rs
@@ -1,8 +1,8 @@
 use crate::component::datatype::DataType;
 use crate::component::field::Field;
+use crate::storage::diskinterface::DiskError;
 use crate::storage::diskinterface::TableMeta;
 use crate::storage::file::File;
-use crate::storage::file::FileError;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
@@ -72,7 +72,7 @@ pub enum TableError {
     InsertFieldNotNullMismatched(String),
     InsertFieldDefaultMismatched(String),
     SelectFieldNotExisted(String),
-    CausedByFile(FileError),
+    CausedByFile(DiskError),
     KeyNotExist,
 }
 

--- a/src/component/table.rs
+++ b/src/component/table.rs
@@ -1,8 +1,6 @@
 use crate::component::datatype::DataType;
 use crate::component::field::Field;
-use crate::storage::diskinterface::DiskError;
-use crate::storage::diskinterface::TableMeta;
-use crate::storage::file::File;
+use crate::storage::diskinterface::{DiskError, DiskInterface, TableMeta};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
@@ -123,8 +121,8 @@ impl Table {
     /// Load a table with meta data
     #[allow(dead_code)]
     pub fn load_meta(username: &str, db_name: &str, table_name: &str) -> Result<Table, TableError> {
-        let meta =
-            File::load_table_meta(username, db_name, table_name, None).map_err(|e| TableError::CausedByFile(e))?;
+        let meta = DiskInterface::load_table_meta(username, db_name, table_name, None)
+            .map_err(|e| TableError::CausedByFile(e))?;
         let mut table = Table::new(table_name);
 
         table.format_meta(meta);
@@ -145,7 +143,7 @@ impl Table {
     /// load the particular range of rows from storage
     pub fn load_rows_data(&mut self, username: &str, db_name: &str) -> Result<(), TableError> {
         // TODO: read index file, find all row data range, call fetch_rows
-        //let row_data = File::fetch_rows(username, db_name, self.name, , None).unwrap().map_err(|e| TableError::CauseByFile(e))?;
+        //let row_data = DiskInterface::fetch_rows(username, db_name, self.name, , None).unwrap().map_err(|e| TableError::CauseByFile(e))?;
         //self.rows = row_data;
         self.is_data_loaded = true;
         Ok(())

--- a/src/component/table.rs
+++ b/src/component/table.rs
@@ -1,8 +1,8 @@
 use crate::component::datatype::DataType;
 use crate::component::field::Field;
+use crate::storage::diskinterface::TableMeta;
 use crate::storage::file::File;
 use crate::storage::file::FileError;
-use crate::storage::file::TableMeta;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -1,7 +1,6 @@
 use crate::manager::pool::{Pool, PoolError};
 use crate::sql::parser::{Parser, ParserError};
-use crate::storage::diskinterface::DiskError;
-use crate::storage::file::File;
+use crate::storage::diskinterface::{DiskError, DiskInterface};
 use crate::Response;
 use std::fmt;
 
@@ -144,12 +143,12 @@ impl Request {
         if name == "" {
             return Err(RequestError::UserNotExist(name.to_string()));
         } else {
-            let users = match File::get_usernames(Some(dotenv!("FILE_BASE_PATH"))) {
+            let users = match DiskInterface::get_usernames(Some(dotenv!("FILE_BASE_PATH"))) {
                 Ok(us) => us,
                 Err(ret) => return Err(RequestError::DiskError(ret)),
             };
             if !users.contains(&name.to_string()) {
-                match File::create_username(name, Some(dotenv!("FILE_BASE_PATH"))) {
+                match DiskInterface::create_username(name, Some(dotenv!("FILE_BASE_PATH"))) {
                     Ok(_) => {}
                     Err(ret) => return Err(RequestError::DiskError(ret)),
                 }

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -1,6 +1,7 @@
 use crate::manager::pool::{Pool, PoolError};
 use crate::sql::parser::{Parser, ParserError};
-use crate::storage::file::{File, FileError};
+use crate::storage::diskinterface::DiskError;
+use crate::storage::file::File;
 use crate::Response;
 use std::fmt;
 
@@ -17,7 +18,7 @@ pub struct Request {
 pub enum RequestError {
     PoolError(PoolError),
     CauseByParser(ParserError),
-    FileError(FileError),
+    DiskError(DiskError),
     UserNotExist(String),
     CreateDBBeforeCmd,
     BadRequest,
@@ -29,7 +30,7 @@ impl fmt::Display for RequestError {
         match *self {
             RequestError::PoolError(ref e) => write!(f, "error caused by pool: {}", e),
             RequestError::CauseByParser(ref e) => write!(f, "error caused by parser: {}", e),
-            RequestError::FileError(ref e) => write!(f, "error caused by file: {}", e),
+            RequestError::DiskError(ref e) => write!(f, "error caused by file: {}", e),
             RequestError::UserNotExist(ref s) => write!(f, "user: {} not found", s),
             RequestError::CreateDBBeforeCmd => write!(f, "please create a database before any other commands"),
             RequestError::BadRequest => write!(f, "BadRequest, invalid request format"),
@@ -145,12 +146,12 @@ impl Request {
         } else {
             let users = match File::get_usernames(Some(dotenv!("FILE_BASE_PATH"))) {
                 Ok(us) => us,
-                Err(ret) => return Err(RequestError::FileError(ret)),
+                Err(ret) => return Err(RequestError::DiskError(ret)),
             };
             if !users.contains(&name.to_string()) {
                 match File::create_username(name, Some(dotenv!("FILE_BASE_PATH"))) {
                     Ok(_) => {}
-                    Err(ret) => return Err(RequestError::FileError(ret)),
+                    Err(ret) => return Err(RequestError::DiskError(ret)),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use env_logger;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
-use crate::storage::file::File;
+use crate::storage::diskinterface::DiskInterface;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -89,7 +89,7 @@ fn env_init() {
     // check ../.env: FILE_BASE_PATH, create usernames.json
     let path = dotenv!("FILE_BASE_PATH");
     if !Path::new(path).exists() {
-        File::create_file_base(Some(path));
+        DiskInterface::create_file_base(Some(path));
     }
 }
 

--- a/src/manager/pool.rs
+++ b/src/manager/pool.rs
@@ -155,7 +155,7 @@ impl Pool {
                 }
             }
             if !new_row.is_empty() {
-                match File::append_rows(
+                match DiskInterface::append_rows(
                     &sql.user.name,
                     &sql.database.name,
                     &name,
@@ -163,7 +163,7 @@ impl Pool {
                     Some(dotenv!("FILE_BASE_PATH")),
                 ) {
                     Ok(_) => {}
-                    Err(e) => return Err(PoolError::FileError(e)),
+                    Err(e) => return Err(PoolError::DiskError(e)),
                 }
             }
         }

--- a/src/storage/bytescoder.rs
+++ b/src/storage/bytescoder.rs
@@ -4,7 +4,7 @@ use crate::component::datatype::DataType;
 use crate::component::field;
 use crate::component::field::Field;
 use crate::component::table::Row;
-use crate::storage::file::TableMeta;
+use crate::storage::diskinterface::TableMeta;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::fmt;

--- a/src/storage/bytescoder.rs
+++ b/src/storage/bytescoder.rs
@@ -218,12 +218,14 @@ mod tests {
     pub fn test_row_encode_decode() {
         let mut aff_table_meta = TableMeta {
             name: "Affiliates".to_string(),
+            username: "crazyguy".to_string(),
+            db_name: "BookerDB".to_string(),
+            path_tsv: "Affiliates.tsv".to_string(),
+            path_bin: "Affiliates.bin".to_string(),
             primary_key: vec!["AffID".to_string()],
             foreign_key: vec![],
             reference_table: None,
             reference_attr: None,
-            path_tsv: "Affiliates.tsv".to_string(),
-            path_bin: "Affiliates.bin".to_string(),
             attr_offset_ranges: vec![vec![0, 1], vec![1, 5], vec![5, 55], vec![55, 95], vec![95, 115]],
             row_length: 115,
             // ignore attrs checking

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -173,6 +173,10 @@ impl fmt::Display for DiskError {
 
 #[allow(dead_code)]
 impl DiskInterface {
+    pub fn create_file_base(file_base_path: Option<&str>) -> Result<(), DiskError> {
+        Ok(File::create_file_base(file_base_path)?)
+    }
+
     pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
         Ok(File::create_username(username, file_base_path)?)
     }

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -4,6 +4,7 @@ use crate::component::table::Row;
 use crate::component::table::Table;
 use crate::storage::bytescoder;
 use crate::storage::file::File;
+use crate::storage::index::Index;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs;
@@ -414,6 +415,38 @@ impl DiskInterface {
             DataType::Int => 4,
             DataType::Varchar(length) => length.clone() as u32,
         }
+    }
+
+    pub fn build_index_from_table_bin(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<Index, DiskError> {
+        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, file_base_path)?;
+        let mut index = Index::new(table_meta)?;
+        index.build_from_bin(file_base_path)?;
+
+        Ok(index)
+    }
+
+    pub fn load_index(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<Index, DiskError> {
+        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, file_base_path)?;
+        let mut index = Index::new(table_meta)?;
+        index.load(file_base_path)?;
+
+        Ok(index)
+    }
+
+    pub fn save_index(index: &Index, file_base_path: Option<&str>) -> Result<(), DiskError> {
+        index.save(file_base_path)?;
+
+        Ok(())
     }
 }
 

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -1,3 +1,4 @@
+use crate::component::datatype::DataType;
 use crate::component::field::Field;
 use crate::component::table::Row;
 use crate::component::table::Table;
@@ -83,6 +84,7 @@ pub enum DiskError {
     TableNotExists,
     TableBinNotExists,
     TableTsvNotExists,
+    TableIdxFileNotExists,
     JsonParse,
     RangeContainsDeletedRecord,
     RangeExceedLatestRecord,
@@ -130,6 +132,10 @@ impl fmt::Display for DiskError {
             DiskError::TableNotExists => write!(f, "Table not exists. Please create table first."),
             DiskError::TableBinNotExists => write!(f, "Table exists but correspoding bin file is lost."),
             DiskError::TableTsvNotExists => write!(f, "Table exists but correspoding tsv file is lost."),
+            DiskError::TableIdxFileNotExists => write!(
+                f,
+                "Index file does not exist. Please build and save it before you can load from it."
+            ),
             DiskError::JsonParse => write!(f, "JSON parsing error."),
             DiskError::RangeContainsDeletedRecord => write!(f, "The range of rows to fetch contains deleted records."),
             DiskError::RangeExceedLatestRecord => {
@@ -143,33 +149,6 @@ impl fmt::Display for DiskError {
         }
     }
 }
-
-// #[derive(Debug)]
-// pub enum IndexError {
-//     OpenFileError,
-//     CreateFileError,
-//     BuildIntIndexTableError,
-//     ReadIntIndexTableError,
-//     BuildStringIndexTableError,
-//     ReadStringIndexTableError,
-//     WriteIndexError,
-//     InsertValueMismatchIndex,
-// }
-
-// impl fmt::Display for IndexError {
-//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//         match *self {
-//             IndexError::OpenFileError => write!(f, "cannot open file"),
-//             IndexError::CreateFileError => write!(f, "cannot create file"),
-//             IndexError::BuildIntIndexTableError => write!(f, "Build int index table error"),
-//             IndexError::ReadIntIndexTableError => write!(f, "Read int index table error"),
-//             IndexError::BuildStringIndexTableError => write!(f, "Build string index table error"),
-//             IndexError::ReadStringIndexTableError => write!(f, "Read string index table error"),
-//             IndexError::WriteIndexError => write!(f, "Write index table error"),
-//             IndexError::InsertValueMismatchIndex => write!(f, "Type of the insert value mismatches index"),
-//         }
-//     }
-// }
 
 #[allow(dead_code)]
 impl DiskInterface {
@@ -410,6 +389,16 @@ impl DiskInterface {
         }
 
         Ok(())
+    }
+
+    pub fn get_datatype_size(datatype: &DataType) -> u32 {
+        match datatype {
+            DataType::Char(length) => length.clone() as u32,
+            DataType::Double => 8,
+            DataType::Float => 4,
+            DataType::Int => 4,
+            DataType::Varchar(length) => length.clone() as u32,
+        }
     }
 }
 

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -1,0 +1,174 @@
+use crate::component::field::Field;
+use crate::component::table::Row;
+use crate::component::table::Table;
+use crate::storage::file;
+use crate::storage::file::File;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct DiskInterface {
+    /* definition */
+// Ideally, DiskInterface is a stateless struct
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TableMeta {
+    pub name: String,
+    pub path_tsv: String,
+    pub path_bin: String,
+    pub primary_key: Vec<String>,
+    pub foreign_key: Vec<String>,
+    pub reference_table: Option<String>,
+    pub reference_attr: Option<String>,
+    pub row_length: u32,
+    pub attrs: HashMap<String, Field>,
+    pub attrs_order: Vec<String>,
+    pub attr_offset_ranges: Vec<Vec<u32>>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum DiskInterfaceError {
+    File,
+    // Index,
+}
+
+impl From<file::FileError> for DiskInterfaceError {
+    fn from(_err: file::FileError) -> DiskInterfaceError {
+        DiskInterfaceError::File
+    }
+}
+
+#[allow(dead_code)]
+impl DiskInterfaceError {
+    pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+        Ok(File::create_username(username, file_base_path)?)
+    }
+
+    pub fn get_usernames(file_base_path: Option<&str>) -> Result<Vec<String>, DiskInterfaceError> {
+        Ok(File::get_usernames(file_base_path)?)
+    }
+
+    pub fn remove_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+        Ok(File::remove_username(username, file_base_path)?)
+    }
+
+    pub fn create_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+        Ok(File::create_db(username, db_name, file_base_path)?)
+    }
+
+    pub fn get_dbs(username: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskInterfaceError> {
+        Ok(File::get_dbs(username, file_base_path)?)
+    }
+
+    pub fn remove_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+        Ok(File::remove_db(username, db_name, file_base_path)?)
+    }
+
+    pub fn create_table(
+        username: &str,
+        db_name: &str,
+        table: &Table,
+        file_base_path: Option<&str>,
+    ) -> Result<(), DiskInterfaceError> {
+        Ok(File::create_table(username, db_name, table, file_base_path)?)
+    }
+
+    pub fn get_tables(
+        username: &str,
+        db_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<Vec<String>, DiskInterfaceError> {
+        Ok(File::get_tables(username, db_name, file_base_path)?)
+    }
+
+    pub fn load_tables_meta(
+        username: &str,
+        db_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<Vec<TableMeta>, DiskInterfaceError> {
+        Ok(File::load_tables_meta(username, db_name, file_base_path)?)
+    }
+
+    pub fn load_table_meta(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<TableMeta, DiskInterfaceError> {
+        Ok(File::load_table_meta(username, db_name, table_name, file_base_path)?)
+    }
+
+    pub fn drop_table(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<(), DiskInterfaceError> {
+        Ok(File::drop_table(username, db_name, table_name, file_base_path)?)
+    }
+
+    pub fn append_rows(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        rows: &Vec<Row>,
+        file_base_path: Option<&str>,
+    ) -> Result<(), DiskInterfaceError> {
+        Ok(File::append_rows(username, db_name, table_name, rows, file_base_path)?)
+    }
+
+    pub fn fetch_rows(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        row_range: &Vec<u32>,
+        file_base_path: Option<&str>,
+    ) -> Result<Vec<Row>, DiskInterfaceError> {
+        Ok(File::fetch_rows(
+            username,
+            db_name,
+            table_name,
+            row_range,
+            file_base_path,
+        )?)
+    }
+
+    pub fn delete_rows(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        row_range: &Vec<u32>,
+        file_base_path: Option<&str>,
+    ) -> Result<(), DiskInterfaceError> {
+        Ok(File::delete_rows(
+            username,
+            db_name,
+            table_name,
+            row_range,
+            file_base_path,
+        )?)
+    }
+
+    pub fn modify_rows(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        row_range: &Vec<u32>,
+        new_rows: &Vec<Row>,
+        file_base_path: Option<&str>,
+    ) -> Result<(), DiskInterfaceError> {
+        Ok(File::modify_rows(
+            username,
+            db_name,
+            table_name,
+            row_range,
+            new_rows,
+            file_base_path,
+        )?)
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+// }

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -14,6 +14,8 @@ pub struct DiskInterface {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TableMeta {
     pub name: String,
+    pub username: String,
+    pub db_name: String,
     pub path_tsv: String,
     pub path_bin: String,
     pub primary_key: Vec<String>,

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -92,6 +92,7 @@ pub enum DiskError {
     AttrNotExists,
     BytesError,
     DuplicatedKey,
+    IndexKeyNotFound,
 }
 
 impl From<io::Error> for DiskError {
@@ -148,6 +149,9 @@ impl fmt::Display for DiskError {
             DiskError::AttrNotExists => write!(f, "The row does not contain specified attribute."),
             DiskError::BytesError => write!(f, "Error raised from BytesCoder."),
             DiskError::DuplicatedKey => write!(f, "Attempting to insert an duplicated key to index."),
+            DiskError::IndexKeyNotFound => {
+                write!(f, "Attempting to access or delete a key which does not exist in index.")
+            }
         }
     }
 }

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -160,31 +160,38 @@ impl fmt::Display for DiskError {
 #[allow(dead_code)]
 impl DiskInterface {
     pub fn create_file_base(file_base_path: Option<&str>) -> Result<(), DiskError> {
-        Ok(File::create_file_base(file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::create_file_base(base_path)?)
     }
 
     pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        Ok(File::create_username(username, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::create_username(username, base_path)?)
     }
 
     pub fn get_usernames(file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        Ok(File::get_usernames(file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::get_usernames(base_path)?)
     }
 
     pub fn remove_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        Ok(File::remove_username(username, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::remove_username(username, base_path)?)
     }
 
     pub fn create_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        Ok(File::create_db(username, db_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::create_db(username, db_name, base_path)?)
     }
 
     pub fn get_dbs(username: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        Ok(File::get_dbs(username, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::get_dbs(username, base_path)?)
     }
 
     pub fn remove_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        Ok(File::remove_db(username, db_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::remove_db(username, db_name, base_path)?)
     }
 
     pub fn create_table(
@@ -193,11 +200,13 @@ impl DiskInterface {
         table: &Table,
         file_base_path: Option<&str>,
     ) -> Result<(), DiskError> {
-        Ok(File::create_table(username, db_name, table, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::create_table(username, db_name, table, base_path)?)
     }
 
     pub fn get_tables(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        Ok(File::get_tables(username, db_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::get_tables(username, db_name, base_path)?)
     }
 
     pub fn load_tables_meta(
@@ -205,7 +214,8 @@ impl DiskInterface {
         db_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<Vec<TableMeta>, DiskError> {
-        Ok(File::load_tables_meta(username, db_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::load_tables_meta(username, db_name, base_path)?)
     }
 
     pub fn load_table_meta(
@@ -214,7 +224,8 @@ impl DiskInterface {
         table_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<TableMeta, DiskError> {
-        Ok(File::load_table_meta(username, db_name, table_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::load_table_meta(username, db_name, table_name, base_path)?)
     }
 
     pub fn drop_table(
@@ -223,7 +234,8 @@ impl DiskInterface {
         table_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<(), DiskError> {
-        Ok(File::drop_table(username, db_name, table_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::drop_table(username, db_name, table_name, base_path)?)
     }
 
     pub fn append_rows(
@@ -233,7 +245,8 @@ impl DiskInterface {
         rows: &Vec<Row>,
         file_base_path: Option<&str>,
     ) -> Result<(), DiskError> {
-        Ok(File::append_rows(username, db_name, table_name, rows, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::append_rows(username, db_name, table_name, rows, base_path)?)
     }
 
     pub fn fetch_rows(
@@ -243,13 +256,8 @@ impl DiskInterface {
         row_range: &Vec<u32>,
         file_base_path: Option<&str>,
     ) -> Result<Vec<Row>, DiskError> {
-        Ok(File::fetch_rows(
-            username,
-            db_name,
-            table_name,
-            row_range,
-            file_base_path,
-        )?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::fetch_rows(username, db_name, table_name, row_range, base_path)?)
     }
 
     pub fn delete_rows(
@@ -259,13 +267,8 @@ impl DiskInterface {
         row_range: &Vec<u32>,
         file_base_path: Option<&str>,
     ) -> Result<(), DiskError> {
-        Ok(File::delete_rows(
-            username,
-            db_name,
-            table_name,
-            row_range,
-            file_base_path,
-        )?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::delete_rows(username, db_name, table_name, row_range, base_path)?)
     }
 
     pub fn modify_rows(
@@ -276,13 +279,9 @@ impl DiskInterface {
         new_rows: &Vec<Row>,
         file_base_path: Option<&str>,
     ) -> Result<(), DiskError> {
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
         Ok(File::modify_rows(
-            username,
-            db_name,
-            table_name,
-            row_range,
-            new_rows,
-            file_base_path,
+            username, db_name, table_name, row_range, new_rows, base_path,
         )?)
     }
 
@@ -292,7 +291,8 @@ impl DiskInterface {
         table_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<u32, DiskError> {
-        Ok(File::get_num_rows(username, db_name, table_name, file_base_path)?)
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        Ok(File::get_num_rows(username, db_name, table_name, base_path)?)
     }
 
     pub fn storage_hierarchy_check(
@@ -423,9 +423,10 @@ impl DiskInterface {
         table_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<Index, DiskError> {
-        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, file_base_path)?;
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, Some(base_path))?;
         let mut index = Index::new(table_meta)?;
-        index.build_from_bin(file_base_path)?;
+        index.build_from_bin(base_path)?;
 
         Ok(index)
     }
@@ -436,15 +437,17 @@ impl DiskInterface {
         table_name: &str,
         file_base_path: Option<&str>,
     ) -> Result<Index, DiskError> {
-        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, file_base_path)?;
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        let table_meta = DiskInterface::load_table_meta(username, db_name, table_name, Some(base_path))?;
         let mut index = Index::new(table_meta)?;
-        index.load(file_base_path)?;
+        index.load(base_path)?;
 
         Ok(index)
     }
 
     pub fn save_index(index: &Index, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        index.save(file_base_path)?;
+        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
+        index.save(base_path)?;
 
         Ok(())
     }

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -91,6 +91,7 @@ pub enum DiskError {
     RangeAndNumRowsMismatch,
     AttrNotExists,
     BytesError,
+    DuplicatedKey,
 }
 
 impl From<io::Error> for DiskError {
@@ -146,6 +147,7 @@ impl fmt::Display for DiskError {
             }
             DiskError::AttrNotExists => write!(f, "The row does not contain specified attribute."),
             DiskError::BytesError => write!(f, "Error raised from BytesCoder."),
+            DiskError::DuplicatedKey => write!(f, "Attempting to insert an duplicated key to index."),
         }
     }
 }
@@ -277,6 +279,15 @@ impl DiskInterface {
             new_rows,
             file_base_path,
         )?)
+    }
+
+    pub fn get_num_rows(
+        username: &str,
+        db_name: &str,
+        table_name: &str,
+        file_base_path: Option<&str>,
+    ) -> Result<u32, DiskError> {
+        Ok(File::get_num_rows(username, db_name, table_name, file_base_path)?)
     }
 
     pub fn storage_hierarchy_check(

--- a/src/storage/diskinterface.rs
+++ b/src/storage/diskinterface.rs
@@ -1,14 +1,51 @@
 use crate::component::field::Field;
 use crate::component::table::Row;
 use crate::component::table::Table;
-use crate::storage::file;
+use crate::storage::bytescoder;
 use crate::storage::file::File;
 use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
 
 #[derive(Debug, Clone)]
 pub struct DiskInterface {
     /* definition */
 // Ideally, DiskInterface is a stateless struct
+}
+
+// structure of `usernames.json`
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UsernamesJson {
+    pub usernames: Vec<UsernameInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UsernameInfo {
+    pub name: String,
+    pub path: String,
+}
+
+// structure of `dbs.json`
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DbsJson {
+    pub dbs: Vec<DbInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DbInfo {
+    pub name: String,
+    pub path: String,
+}
+
+// structure of `tables.json`
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TablesJson {
+    pub tables: Vec<TableMeta>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -29,40 +66,134 @@ pub struct TableMeta {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum DiskInterfaceError {
-    File,
-    // Index,
+pub enum DiskError {
+    Io,
+    BaseDirExists,
+    BaseDirNotExists,
+    UsernamesJsonNotExists,
+    UsernameExists,
+    UsernameNotExists,
+    UsernameDirNotExists,
+    DbsJsonNotExists,
+    DbExists,
+    DbNotExists,
+    DbDirNotExists,
+    TablesJsonNotExists,
+    TableExists,
+    TableNotExists,
+    TableBinNotExists,
+    TableTsvNotExists,
+    JsonParse,
+    RangeContainsDeletedRecord,
+    RangeExceedLatestRecord,
+    RangeAndNumRowsMismatch,
+    AttrNotExists,
+    BytesError,
 }
 
-impl From<file::FileError> for DiskInterfaceError {
-    fn from(_err: file::FileError) -> DiskInterfaceError {
-        DiskInterfaceError::File
+impl From<io::Error> for DiskError {
+    fn from(_err: io::Error) -> DiskError {
+        DiskError::Io
     }
 }
 
+impl From<serde_json::Error> for DiskError {
+    fn from(_err: serde_json::Error) -> DiskError {
+        DiskError::JsonParse
+    }
+}
+
+impl From<bytescoder::BytesCoderError> for DiskError {
+    fn from(_err: bytescoder::BytesCoderError) -> DiskError {
+        DiskError::BytesError
+    }
+}
+
+impl fmt::Display for DiskError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            DiskError::Io => write!(f, "No such file or directory."),
+            DiskError::BaseDirExists => write!(f, "Base dir already exists and cannot be created again."),
+            DiskError::BaseDirNotExists => write!(f, "Base data directory not exists. All data lost."),
+            DiskError::UsernamesJsonNotExists => write!(f, "The file `usernames.json` is lost"),
+            DiskError::UsernameExists => write!(f, "User name already exists and cannot be created again."),
+            DiskError::UsernameNotExists => {
+                write!(f, "Specified user name not exists. Please create this username first.")
+            }
+            DiskError::UsernameDirNotExists => write!(f, "Username exists but corresponding data folder is lost."),
+            DiskError::DbsJsonNotExists => write!(f, "The `dbs.json` of the username is lost"),
+            DiskError::DbExists => write!(f, "DB already exists and cannot be created again."),
+            DiskError::DbNotExists => write!(f, "DB not exists. Please create DB first."),
+            DiskError::DbDirNotExists => write!(f, "DB exists but correspoding data folder is lost."),
+            DiskError::TablesJsonNotExists => write!(f, "The `tables.json` of the DB is lost."),
+            DiskError::TableExists => write!(f, "Table already exists and cannot be created again."),
+            DiskError::TableNotExists => write!(f, "Table not exists. Please create table first."),
+            DiskError::TableBinNotExists => write!(f, "Table exists but correspoding bin file is lost."),
+            DiskError::TableTsvNotExists => write!(f, "Table exists but correspoding tsv file is lost."),
+            DiskError::JsonParse => write!(f, "JSON parsing error."),
+            DiskError::RangeContainsDeletedRecord => write!(f, "The range of rows to fetch contains deleted records."),
+            DiskError::RangeExceedLatestRecord => {
+                write!(f, "The range of rows to fetch exceeds the latest record on the table.")
+            }
+            DiskError::RangeAndNumRowsMismatch => {
+                write!(f, "The range of rows does not match number of rows to be modified.")
+            }
+            DiskError::AttrNotExists => write!(f, "The row does not contain specified attribute."),
+            DiskError::BytesError => write!(f, "Error raised from BytesCoder."),
+        }
+    }
+}
+
+// #[derive(Debug)]
+// pub enum IndexError {
+//     OpenFileError,
+//     CreateFileError,
+//     BuildIntIndexTableError,
+//     ReadIntIndexTableError,
+//     BuildStringIndexTableError,
+//     ReadStringIndexTableError,
+//     WriteIndexError,
+//     InsertValueMismatchIndex,
+// }
+
+// impl fmt::Display for IndexError {
+//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//         match *self {
+//             IndexError::OpenFileError => write!(f, "cannot open file"),
+//             IndexError::CreateFileError => write!(f, "cannot create file"),
+//             IndexError::BuildIntIndexTableError => write!(f, "Build int index table error"),
+//             IndexError::ReadIntIndexTableError => write!(f, "Read int index table error"),
+//             IndexError::BuildStringIndexTableError => write!(f, "Build string index table error"),
+//             IndexError::ReadStringIndexTableError => write!(f, "Read string index table error"),
+//             IndexError::WriteIndexError => write!(f, "Write index table error"),
+//             IndexError::InsertValueMismatchIndex => write!(f, "Type of the insert value mismatches index"),
+//         }
+//     }
+// }
+
 #[allow(dead_code)]
-impl DiskInterfaceError {
-    pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+impl DiskInterface {
+    pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
         Ok(File::create_username(username, file_base_path)?)
     }
 
-    pub fn get_usernames(file_base_path: Option<&str>) -> Result<Vec<String>, DiskInterfaceError> {
+    pub fn get_usernames(file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
         Ok(File::get_usernames(file_base_path)?)
     }
 
-    pub fn remove_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+    pub fn remove_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
         Ok(File::remove_username(username, file_base_path)?)
     }
 
-    pub fn create_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+    pub fn create_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
         Ok(File::create_db(username, db_name, file_base_path)?)
     }
 
-    pub fn get_dbs(username: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskInterfaceError> {
+    pub fn get_dbs(username: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
         Ok(File::get_dbs(username, file_base_path)?)
     }
 
-    pub fn remove_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskInterfaceError> {
+    pub fn remove_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
         Ok(File::remove_db(username, db_name, file_base_path)?)
     }
 
@@ -71,15 +202,11 @@ impl DiskInterfaceError {
         db_name: &str,
         table: &Table,
         file_base_path: Option<&str>,
-    ) -> Result<(), DiskInterfaceError> {
+    ) -> Result<(), DiskError> {
         Ok(File::create_table(username, db_name, table, file_base_path)?)
     }
 
-    pub fn get_tables(
-        username: &str,
-        db_name: &str,
-        file_base_path: Option<&str>,
-    ) -> Result<Vec<String>, DiskInterfaceError> {
+    pub fn get_tables(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
         Ok(File::get_tables(username, db_name, file_base_path)?)
     }
 
@@ -87,7 +214,7 @@ impl DiskInterfaceError {
         username: &str,
         db_name: &str,
         file_base_path: Option<&str>,
-    ) -> Result<Vec<TableMeta>, DiskInterfaceError> {
+    ) -> Result<Vec<TableMeta>, DiskError> {
         Ok(File::load_tables_meta(username, db_name, file_base_path)?)
     }
 
@@ -96,7 +223,7 @@ impl DiskInterfaceError {
         db_name: &str,
         table_name: &str,
         file_base_path: Option<&str>,
-    ) -> Result<TableMeta, DiskInterfaceError> {
+    ) -> Result<TableMeta, DiskError> {
         Ok(File::load_table_meta(username, db_name, table_name, file_base_path)?)
     }
 
@@ -105,7 +232,7 @@ impl DiskInterfaceError {
         db_name: &str,
         table_name: &str,
         file_base_path: Option<&str>,
-    ) -> Result<(), DiskInterfaceError> {
+    ) -> Result<(), DiskError> {
         Ok(File::drop_table(username, db_name, table_name, file_base_path)?)
     }
 
@@ -115,7 +242,7 @@ impl DiskInterfaceError {
         table_name: &str,
         rows: &Vec<Row>,
         file_base_path: Option<&str>,
-    ) -> Result<(), DiskInterfaceError> {
+    ) -> Result<(), DiskError> {
         Ok(File::append_rows(username, db_name, table_name, rows, file_base_path)?)
     }
 
@@ -125,7 +252,7 @@ impl DiskInterfaceError {
         table_name: &str,
         row_range: &Vec<u32>,
         file_base_path: Option<&str>,
-    ) -> Result<Vec<Row>, DiskInterfaceError> {
+    ) -> Result<Vec<Row>, DiskError> {
         Ok(File::fetch_rows(
             username,
             db_name,
@@ -141,7 +268,7 @@ impl DiskInterfaceError {
         table_name: &str,
         row_range: &Vec<u32>,
         file_base_path: Option<&str>,
-    ) -> Result<(), DiskInterfaceError> {
+    ) -> Result<(), DiskError> {
         Ok(File::delete_rows(
             username,
             db_name,
@@ -158,7 +285,7 @@ impl DiskInterfaceError {
         row_range: &Vec<u32>,
         new_rows: &Vec<Row>,
         file_base_path: Option<&str>,
-    ) -> Result<(), DiskInterfaceError> {
+    ) -> Result<(), DiskError> {
         Ok(File::modify_rows(
             username,
             db_name,
@@ -167,6 +294,118 @@ impl DiskInterfaceError {
             new_rows,
             file_base_path,
         )?)
+    }
+
+    pub fn storage_hierarchy_check(
+        base_path: &str,
+        username: Option<&str>,
+        db_name: Option<&str>,
+        table_name: Option<&str>,
+    ) -> Result<(), DiskError> {
+        // check if base directory exists
+        if !Path::new(base_path).exists() {
+            return Err(DiskError::BaseDirNotExists);
+        }
+
+        // check if `usernames.json` exists
+        let usernames_json_path = format!("{}/{}", base_path, "usernames.json");
+        if !Path::new(&usernames_json_path).exists() {
+            return Err(DiskError::UsernamesJsonNotExists);
+        }
+
+        // base level check passed
+        if username == None {
+            return Ok(());
+        }
+
+        // check if username exists
+        let usernames_file = fs::File::open(&usernames_json_path)?;
+        let usernames_json: UsernamesJson = serde_json::from_reader(usernames_file)?;
+        if !usernames_json
+            .usernames
+            .iter()
+            .map(|username_info| username_info.name.clone())
+            .collect::<Vec<String>>()
+            .contains(&username.unwrap().to_string())
+        {
+            return Err(DiskError::UsernameNotExists);
+        }
+
+        // check if username directory exists
+        let username_path = format!("{}/{}", base_path, username.unwrap());
+        if !Path::new(&username_path).exists() {
+            return Err(DiskError::UsernameDirNotExists);
+        }
+
+        // check if `dbs.json` exists
+        let dbs_json_path = format!("{}/{}", username_path, "dbs.json");
+        if !Path::new(&dbs_json_path).exists() {
+            return Err(DiskError::DbsJsonNotExists);
+        }
+
+        // username level check passed
+        if db_name == None {
+            return Ok(());
+        }
+
+        // check if db exists
+        let dbs_file = fs::File::open(&dbs_json_path)?;
+        let dbs_json: DbsJson = serde_json::from_reader(dbs_file)?;
+        if !dbs_json
+            .dbs
+            .iter()
+            .map(|db_info| db_info.name.clone())
+            .collect::<Vec<String>>()
+            .contains(&db_name.unwrap().to_string())
+        {
+            return Err(DiskError::DbNotExists);
+        }
+
+        // check if db directory exists
+        let db_path = format!("{}/{}", username_path, db_name.unwrap());
+        if !Path::new(&db_path).exists() {
+            return Err(DiskError::DbDirNotExists);
+        }
+
+        // check if `tables.json` exists
+        let tables_json_path = format!("{}/{}", db_path, "tables.json");
+        if !Path::new(&tables_json_path).exists() {
+            return Err(DiskError::TablesJsonNotExists);
+        }
+
+        // db level check passed
+        if table_name == None {
+            return Ok(());
+        }
+
+        // check if table exists
+        let tables_file = fs::File::open(&tables_json_path)?;
+        let tables_json: TablesJson = serde_json::from_reader(tables_file)?;
+        if !tables_json
+            .tables
+            .iter()
+            .map(|table_meta| table_meta.name.clone())
+            .collect::<Vec<String>>()
+            .contains(&table_name.unwrap().to_string())
+        {
+            return Err(DiskError::TableNotExists);
+        }
+
+        // check if table bin exists
+        let table_bin_path = format!("{}/{}.bin", db_path, table_name.unwrap());
+        if !Path::new(&table_bin_path).exists() {
+            return Err(DiskError::TableBinNotExists);
+        }
+
+        if dotenv!("ENABLE_TSV") == "true" {
+            // check if table tsv exists
+            let table_tsv_path = format!("{}/{}.tsv", db_path, table_name.unwrap());
+            if !Path::new(&table_tsv_path).exists() {
+                return Err(DiskError::TableTsvNotExists);
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -1,4 +1,3 @@
-use crate::component::datatype::DataType;
 use crate::component::field::Field;
 use crate::component::table::Row;
 use crate::component::table::Table;
@@ -325,7 +324,7 @@ impl File {
         new_table_meta.attr_offset_ranges = vec![vec![0, 1]];
         let attr_sizes: Vec<u32> = new_table_meta.attrs_order[1..]
             .iter()
-            .map(|attr_name| File::get_datatype_size(&new_table_meta.attrs[attr_name].datatype))
+            .map(|attr_name| DiskInterface::get_datatype_size(&new_table_meta.attrs[attr_name].datatype))
             .collect();
 
         // `__valid__` attr occupies 1 byte
@@ -864,16 +863,6 @@ impl File {
         }
 
         Ok(())
-    }
-
-    fn get_datatype_size(datatype: &DataType) -> u32 {
-        match datatype {
-            DataType::Char(length) => length.clone() as u32,
-            DataType::Double => 8,
-            DataType::Float => 4,
-            DataType::Int => 4,
-            DataType::Varchar(length) => length.clone() as u32,
-        }
     }
 }
 

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -19,10 +19,7 @@ pub struct File {
 // TODO: add table-level folders to storage hierarchy
 #[allow(dead_code)]
 impl File {
-    pub fn create_file_base(file_base_path: Option<&str>) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn create_file_base(base_path: &str) -> Result<(), DiskError> {
         // create base data folder if not exists
         if !Path::new(base_path).exists() {
             fs::create_dir_all(base_path)?;
@@ -43,10 +40,7 @@ impl File {
         Ok(())
     }
 
-    pub fn create_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn create_username(username: &str, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward base level
         DiskInterface::storage_hierarchy_check(base_path, None, None, None).map_err(|e| e)?;
 
@@ -97,10 +91,7 @@ impl File {
         Ok(())
     }
 
-    pub fn get_usernames(file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn get_usernames(base_path: &str) -> Result<Vec<String>, DiskError> {
         // perform storage check toward base level
         DiskInterface::storage_hierarchy_check(base_path, None, None, None).map_err(|e| e)?;
 
@@ -118,10 +109,7 @@ impl File {
         Ok(usernames)
     }
 
-    pub fn remove_username(username: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn remove_username(username: &str, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward base level
         DiskInterface::storage_hierarchy_check(base_path, None, None, None).map_err(|e| e)?;
 
@@ -157,10 +145,7 @@ impl File {
         Ok(())
     }
 
-    pub fn create_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn create_db(username: &str, db_name: &str, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward username level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), None, None).map_err(|e| e)?;
 
@@ -207,10 +192,7 @@ impl File {
         Ok(())
     }
 
-    pub fn get_dbs(username: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn get_dbs(username: &str, base_path: &str) -> Result<Vec<String>, DiskError> {
         // perform storage check toward username level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), None, None).map_err(|e| e)?;
 
@@ -228,10 +210,7 @@ impl File {
         Ok(dbs)
     }
 
-    pub fn remove_db(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn remove_db(username: &str, db_name: &str, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward username level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), None, None).map_err(|e| e)?;
 
@@ -264,15 +243,7 @@ impl File {
         Ok(())
     }
 
-    pub fn create_table(
-        username: &str,
-        db_name: &str,
-        table: &Table,
-        file_base_path: Option<&str>,
-    ) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn create_table(username: &str, db_name: &str, table: &Table, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward db level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), None).map_err(|e| e)?;
 
@@ -375,10 +346,7 @@ impl File {
 
     /// get the list of tables in a database
     /// for `show tables`
-    pub fn get_tables(username: &str, db_name: &str, file_base_path: Option<&str>) -> Result<Vec<String>, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn get_tables(username: &str, db_name: &str, base_path: &str) -> Result<Vec<String>, DiskError> {
         // perform storage check toward db level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), None).map_err(|e| e)?;
 
@@ -397,14 +365,7 @@ impl File {
     }
 
     /// load metadata of all tables from the database
-    pub fn load_tables_meta(
-        username: &str,
-        db_name: &str,
-        file_base_path: Option<&str>,
-    ) -> Result<Vec<TableMeta>, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn load_tables_meta(username: &str, db_name: &str, base_path: &str) -> Result<Vec<TableMeta>, DiskError> {
         // perform storage check toward db level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), None).map_err(|e| e)?;
 
@@ -422,11 +383,8 @@ impl File {
         username: &str,
         db_name: &str,
         table_name: &str,
-        file_base_path: Option<&str>,
+        base_path: &str,
     ) -> Result<TableMeta, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
         // perform storage check toward db level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), None).map_err(|e| e)?;
 
@@ -444,15 +402,7 @@ impl File {
         Err(DiskError::TableNotExists)
     }
 
-    pub fn drop_table(
-        username: &str,
-        db_name: &str,
-        table_name: &str,
-        file_base_path: Option<&str>,
-    ) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn drop_table(username: &str, db_name: &str, table_name: &str, base_path: &str) -> Result<(), DiskError> {
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -503,11 +453,8 @@ impl File {
         db_name: &str,
         table_name: &str,
         rows: &Vec<Row>,
-        file_base_path: Option<&str>,
+        base_path: &str,
     ) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -566,11 +513,8 @@ impl File {
         db_name: &str,
         table_name: &str,
         row_range: &Vec<u32>,
-        file_base_path: Option<&str>,
+        base_path: &str,
     ) -> Result<Vec<Row>, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -650,11 +594,8 @@ impl File {
         db_name: &str,
         table_name: &str,
         row_range: &Vec<u32>,
-        file_base_path: Option<&str>,
+        base_path: &str,
     ) -> Result<(), DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -752,15 +693,11 @@ impl File {
         table_name: &str,
         row_range: &Vec<u32>,
         new_rows: &Vec<Row>,
-        file_base_path: Option<&str>,
+        base_path: &str,
     ) -> Result<(), DiskError> {
         if row_range[1] - row_range[0] != new_rows.len() as u32 {
             return Err(DiskError::RangeAndNumRowsMismatch);
         }
-
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -865,15 +802,7 @@ impl File {
         Ok(())
     }
 
-    pub fn get_num_rows(
-        username: &str,
-        db_name: &str,
-        table_name: &str,
-        file_base_path: Option<&str>,
-    ) -> Result<u32, DiskError> {
-        // determine file base path
-        let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
-
+    pub fn get_num_rows(username: &str, db_name: &str, table_name: &str, base_path: &str) -> Result<u32, DiskError> {
         // perform storage check toward table level
         DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name))
             .map_err(|e| e)?;
@@ -914,7 +843,7 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
 
         assert!(Path::new(file_base_path).exists());
 
@@ -922,7 +851,7 @@ mod tests {
         assert!(Path::new(&usernames_json_path).exists());
 
         assert_eq!(
-            File::create_file_base(Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_file_base(Some(file_base_path)).unwrap_err(),
             DiskError::BaseDirExists
         );
     }
@@ -934,9 +863,9 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_username("happyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_username("happyguy", Some(file_base_path)).unwrap();
 
         let usernames_json_path = format!("{}/{}", file_base_path, "usernames.json");
         let usernames_json = fs::read_to_string(usernames_json_path).unwrap();
@@ -972,7 +901,7 @@ mod tests {
         assert_eq!(dbs_json.dbs.len(), 0);
 
         assert_eq!(
-            File::create_username("happyguy", Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_username("happyguy", Some(file_base_path)).unwrap_err(),
             DiskError::UsernameExists
         );
     }
@@ -984,11 +913,11 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_username("happyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_username("happyguy", Some(file_base_path)).unwrap();
 
-        let usernames: Vec<String> = File::get_usernames(Some(file_base_path)).unwrap();
+        let usernames: Vec<String> = DiskInterface::get_usernames(Some(file_base_path)).unwrap();
         assert_eq!(usernames, vec!["crazyguy", "happyguy"]);
     }
 
@@ -999,32 +928,32 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_username("happyguy", Some(file_base_path)).unwrap();
-        File::create_username("sadguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_username("happyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_username("sadguy", Some(file_base_path)).unwrap();
 
-        let usernames: Vec<String> = File::get_usernames(Some(file_base_path)).unwrap();
+        let usernames: Vec<String> = DiskInterface::get_usernames(Some(file_base_path)).unwrap();
         assert_eq!(usernames, vec!["crazyguy", "happyguy", "sadguy"]);
 
-        File::remove_username("happyguy", Some(file_base_path)).unwrap();
+        DiskInterface::remove_username("happyguy", Some(file_base_path)).unwrap();
 
-        let usernames: Vec<String> = File::get_usernames(Some(file_base_path)).unwrap();
+        let usernames: Vec<String> = DiskInterface::get_usernames(Some(file_base_path)).unwrap();
         assert_eq!(usernames, vec!["crazyguy", "sadguy"]);
 
         assert_eq!(
-            File::remove_username("happyguy", Some(file_base_path)).unwrap_err(),
+            DiskInterface::remove_username("happyguy", Some(file_base_path)).unwrap_err(),
             DiskError::UsernameNotExists
         );
 
-        File::remove_username("sadguy", Some(file_base_path)).unwrap();
+        DiskInterface::remove_username("sadguy", Some(file_base_path)).unwrap();
 
-        let usernames: Vec<String> = File::get_usernames(Some(file_base_path)).unwrap();
+        let usernames: Vec<String> = DiskInterface::get_usernames(Some(file_base_path)).unwrap();
         assert_eq!(usernames, vec!["crazyguy"]);
 
-        File::remove_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::remove_username("crazyguy", Some(file_base_path)).unwrap();
 
-        let usernames: Vec<String> = File::get_usernames(Some(file_base_path)).unwrap();
+        let usernames: Vec<String> = DiskInterface::get_usernames(Some(file_base_path)).unwrap();
         assert_eq!(usernames.len(), 0);
     }
 
@@ -1035,10 +964,10 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
 
         let dbs_json_path = format!("{}/{}/{}", file_base_path, "crazyguy", "dbs.json");
         assert!(Path::new(&dbs_json_path).exists());
@@ -1088,11 +1017,11 @@ mod tests {
         assert_eq!(tables_json.tables.len(), 0);
 
         assert_eq!(
-            File::create_db("happyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_db("happyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
             DiskError::UsernameNotExists
         );
         assert_eq!(
-            File::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
             DiskError::DbExists
         );
     }
@@ -1104,24 +1033,24 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("happyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("happyguy", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("happyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("happyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs.len(), 0);
 
-        File::create_db("happyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("happyguy", "BookerDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("happyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("happyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs, vec!["BookerDB"]);
 
-        File::create_db("happyguy", "MovieDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("happyguy", "MovieDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("happyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("happyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs, vec!["BookerDB", "MovieDB"]);
 
         assert_eq!(
-            File::get_dbs("sadguy", Some(file_base_path)).unwrap_err(),
+            DiskInterface::get_dbs("sadguy", Some(file_base_path)).unwrap_err(),
             DiskError::UsernameNotExists
         );
     }
@@ -1133,38 +1062,38 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("crazyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("crazyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs, vec!["BookerDB", "MovieDB", "PhotoDB"]);
 
-        File::remove_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
+        DiskInterface::remove_db("crazyguy", "MovieDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("crazyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("crazyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs, vec!["BookerDB", "PhotoDB"]);
 
         assert_eq!(
-            File::remove_db("happyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
+            DiskInterface::remove_db("happyguy", "BookerDB", Some(file_base_path)).unwrap_err(),
             DiskError::UsernameNotExists
         );
 
-        File::remove_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap();
+        DiskInterface::remove_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("crazyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("crazyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs, vec!["BookerDB"]);
 
         assert_eq!(
-            File::remove_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap_err(),
+            DiskInterface::remove_db("crazyguy", "PhotoDB", Some(file_base_path)).unwrap_err(),
             DiskError::DbNotExists
         );
 
-        File::remove_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::remove_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
-        let dbs: Vec<String> = File::get_dbs("crazyguy", Some(file_base_path)).unwrap();
+        let dbs: Vec<String> = DiskInterface::get_dbs("crazyguy", Some(file_base_path)).unwrap();
         assert_eq!(dbs.len(), 0);
 
         assert!(!Path::new(&format!("{}/{}/{}", file_base_path, "crazyguy", "BookerDB")).exists());
@@ -1179,9 +1108,9 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         let mut aff_table = Table::new("Affiliates");
         aff_table.fields.insert(
@@ -1223,7 +1152,7 @@ mod tests {
         );
         aff_table.primary_key.push("AffID".to_string());
 
-        File::create_table("crazyguy", "BookerDB", &aff_table, Some(file_base_path)).unwrap();
+        DiskInterface::create_table("crazyguy", "BookerDB", &aff_table, Some(file_base_path)).unwrap();
 
         let mut htl_table = Table::new("Hotels");
         htl_table.fields.insert(
@@ -1265,7 +1194,7 @@ mod tests {
         );
         htl_table.primary_key.push("HotelID".to_string());
 
-        File::create_table("crazyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap();
+        DiskInterface::create_table("crazyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap();
 
         let ideal_tables = vec![
             TableMeta {
@@ -1302,17 +1231,17 @@ mod tests {
             },
         ];
 
-        let table_names = File::get_tables("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        let table_names = DiskInterface::get_tables("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         for i in 0..ideal_tables.len() {
             assert_eq!(table_names[i], ideal_tables[i].name);
         }
 
         // load_table_meta
-        assert!(File::load_table_meta("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).is_ok());
-        assert!(File::load_table_meta("crazyguy", "BookerDB", "none_table", Some(file_base_path)).is_err());
+        assert!(DiskInterface::load_table_meta("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).is_ok());
+        assert!(DiskInterface::load_table_meta("crazyguy", "BookerDB", "none_table", Some(file_base_path)).is_err());
 
-        let tables = File::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        let tables = DiskInterface::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         assert_eq!(tables.len(), 2);
 
@@ -1368,19 +1297,19 @@ mod tests {
         }
 
         assert_eq!(
-            File::create_table("happyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_table("happyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap_err(),
             DiskError::UsernameNotExists
         );
         assert_eq!(
-            File::create_table("crazyguy", "MusicDB", &htl_table, Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_table("crazyguy", "MusicDB", &htl_table, Some(file_base_path)).unwrap_err(),
             DiskError::DbNotExists
         );
         assert_eq!(
-            File::create_table("crazyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap_err(),
+            DiskInterface::create_table("crazyguy", "BookerDB", &htl_table, Some(file_base_path)).unwrap_err(),
             DiskError::TableExists
         );
 
-        File::drop_table("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap();
+        DiskInterface::drop_table("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap();
 
         assert!(!Path::new(&format!(
             "{}/{}/{}/{}",
@@ -1396,16 +1325,16 @@ mod tests {
             .exists());
         }
 
-        let tables = File::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        let tables = DiskInterface::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         assert_eq!(tables.len(), 1);
 
         assert_eq!(
-            File::drop_table("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap_err(),
+            DiskInterface::drop_table("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap_err(),
             DiskError::TableNotExists
         );
 
-        File::drop_table("crazyguy", "BookerDB", "Hotels", Some(file_base_path)).unwrap();
+        DiskInterface::drop_table("crazyguy", "BookerDB", "Hotels", Some(file_base_path)).unwrap();
 
         assert!(!Path::new(&format!(
             "{}/{}/{}/{}",
@@ -1421,7 +1350,7 @@ mod tests {
             .exists());
         }
 
-        let tables = File::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        let tables = DiskInterface::load_tables_meta("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         assert_eq!(tables.len(), 0);
     }
@@ -1433,9 +1362,9 @@ mod tests {
             fs::remove_dir_all(file_base_path).unwrap();
         }
 
-        File::create_file_base(Some(file_base_path)).unwrap();
-        File::create_username("crazyguy", Some(file_base_path)).unwrap();
-        File::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
+        DiskInterface::create_file_base(Some(file_base_path)).unwrap();
+        DiskInterface::create_username("crazyguy", Some(file_base_path)).unwrap();
+        DiskInterface::create_db("crazyguy", "BookerDB", Some(file_base_path)).unwrap();
 
         let mut aff_table = Table::new("Affiliates");
         aff_table.fields.insert(
@@ -1477,7 +1406,7 @@ mod tests {
         );
         aff_table.primary_key.push("AffID".to_string());
 
-        File::create_table("crazyguy", "BookerDB", &aff_table, Some(file_base_path)).unwrap();
+        DiskInterface::create_table("crazyguy", "BookerDB", &aff_table, Some(file_base_path)).unwrap();
 
         let data = vec![
             ("AffID", "1"),
@@ -1487,7 +1416,7 @@ mod tests {
         ];
         aff_table.insert_row(data).unwrap();
 
-        File::append_rows(
+        DiskInterface::append_rows(
             "crazyguy",
             "BookerDB",
             "Affiliates",
@@ -1525,7 +1454,7 @@ mod tests {
         ];
         aff_table.insert_row(data).unwrap();
 
-        File::append_rows(
+        DiskInterface::append_rows(
             "crazyguy",
             "BookerDB",
             "Affiliates",
@@ -1551,12 +1480,12 @@ mod tests {
         }
 
         assert_eq!(
-            File::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
+            DiskInterface::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
             3
         );
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 1], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 1], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 1);
 
@@ -1565,7 +1494,7 @@ mod tests {
         }
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 3], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 3], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 3);
 
@@ -1576,7 +1505,7 @@ mod tests {
         }
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 3], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 3], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 2);
 
@@ -1587,23 +1516,26 @@ mod tests {
         }
 
         assert_eq!(
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 4], Some(file_base_path)).unwrap_err(),
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 4], Some(file_base_path))
+                .unwrap_err(),
             DiskError::RangeExceedLatestRecord
         );
 
-        File::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 2], Some(file_base_path)).unwrap();
+        DiskInterface::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 2], Some(file_base_path)).unwrap();
 
         assert_eq!(
-            File::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 2], Some(file_base_path)).unwrap_err(),
+            DiskInterface::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![1, 2], Some(file_base_path))
+                .unwrap_err(),
             DiskError::RangeContainsDeletedRecord,
         );
 
         assert_eq!(
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 2], Some(file_base_path)).unwrap_err(),
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 2], Some(file_base_path))
+                .unwrap_err(),
             DiskError::RangeContainsDeletedRecord,
         );
 
-        File::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 1], Some(file_base_path)).unwrap();
+        DiskInterface::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![0, 1], Some(file_base_path)).unwrap();
 
         if dotenv!("ENABLE_TSV") == "true" {
             let aff_tsv_content: Vec<String> = fs::read_to_string(&format!(
@@ -1645,7 +1577,7 @@ mod tests {
         ];
         aff_table.insert_row(data).unwrap();
 
-        File::append_rows(
+        DiskInterface::append_rows(
             "crazyguy",
             "BookerDB",
             "Affiliates",
@@ -1668,24 +1600,26 @@ mod tests {
         }
 
         assert_eq!(
-            File::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 7], Some(file_base_path)).unwrap_err(),
+            DiskInterface::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 7], Some(file_base_path))
+                .unwrap_err(),
             DiskError::RangeExceedLatestRecord
         );
 
-        File::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 6], Some(file_base_path)).unwrap();
+        DiskInterface::delete_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 6], Some(file_base_path)).unwrap();
 
         assert_eq!(
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 6], Some(file_base_path)).unwrap_err(),
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![5, 6], Some(file_base_path))
+                .unwrap_err(),
             DiskError::RangeContainsDeletedRecord,
         );
 
         assert_eq!(
-            File::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
+            DiskInterface::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
             6
         );
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 5], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 5], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 3);
 
@@ -1698,7 +1632,7 @@ mod tests {
         *aff_table.rows[2].data.get_mut("AffName").unwrap() = "Leow".to_string();
         *aff_table.rows[4].data.get_mut("AffEmail").unwrap() = "raymond@dee.com".to_string();
         *aff_table.rows[4].data.get_mut("AffPhoneNum").unwrap() = "+886900000015".to_string();
-        File::modify_rows(
+        DiskInterface::modify_rows(
             "crazyguy",
             "BookerDB",
             "Affiliates",
@@ -1709,7 +1643,7 @@ mod tests {
         .unwrap();
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 5], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![2, 5], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 3);
 
@@ -1720,7 +1654,7 @@ mod tests {
         }
 
         assert_eq!(
-            File::modify_rows(
+            DiskInterface::modify_rows(
                 "crazyguy",
                 "BookerDB",
                 "Affiliates",
@@ -1748,7 +1682,7 @@ mod tests {
         ];
         aff_table.insert_row(data).unwrap();
 
-        File::append_rows(
+        DiskInterface::append_rows(
             "crazyguy",
             "BookerDB",
             "Affiliates",
@@ -1758,7 +1692,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            File::modify_rows(
+            DiskInterface::modify_rows(
                 "crazyguy",
                 "BookerDB",
                 "Affiliates",
@@ -1771,7 +1705,7 @@ mod tests {
         );
 
         assert_eq!(
-            File::modify_rows(
+            DiskInterface::modify_rows(
                 "crazyguy",
                 "BookerDB",
                 "Affiliates",
@@ -1784,12 +1718,12 @@ mod tests {
         );
 
         assert_eq!(
-            File::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
+            DiskInterface::get_num_rows("crazyguy", "BookerDB", "Affiliates", Some(file_base_path)).unwrap(),
             8
         );
 
         let rows: Vec<Row> =
-            File::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![6, 8], Some(file_base_path)).unwrap();
+            DiskInterface::fetch_rows("crazyguy", "BookerDB", "Affiliates", &vec![6, 8], Some(file_base_path)).unwrap();
 
         assert_eq!(rows.len(), 2);
 

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -4,6 +4,7 @@ use crate::component::table::Row;
 use crate::component::table::Table;
 use crate::storage::bytescoder;
 use crate::storage::bytescoder::BytesCoder;
+use crate::storage::diskinterface::TableMeta;
 use std::collections::HashMap;
 use std::fmt;
 use std::fs;
@@ -76,21 +77,6 @@ struct TablesJson {
     tables: Vec<TableMeta>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TableMeta {
-    pub name: String,
-    pub path_tsv: String,
-    pub path_bin: String,
-    pub primary_key: Vec<String>,
-    pub foreign_key: Vec<String>,
-    pub reference_table: Option<String>,
-    pub reference_attr: Option<String>,
-    pub row_length: u32,
-    pub attrs: HashMap<String, Field>,
-    pub attrs_order: Vec<String>,
-    pub attr_offset_ranges: Vec<Vec<u32>>,
-}
-
 impl From<io::Error> for FileError {
     fn from(_err: io::Error) -> FileError {
         FileError::Io
@@ -144,6 +130,7 @@ impl fmt::Display for FileError {
     }
 }
 
+// TODO: add table-level folders to storage hierarchy
 #[allow(dead_code)]
 impl File {
     pub fn create_file_base(file_base_path: Option<&str>) -> Result<(), FileError> {

--- a/src/storage/file.rs
+++ b/src/storage/file.rs
@@ -405,6 +405,8 @@ impl File {
         // create new table json instance
         let mut new_table_meta = TableMeta {
             name: table.name.to_string(),
+            username: username.to_string(),
+            db_name: db_name.to_string(),
             path_tsv: format!("{}.tsv", table.name),
             path_bin: format!("{}.bin", table.name),
             primary_key: table.primary_key.clone(),
@@ -1463,12 +1465,14 @@ mod tests {
         let ideal_tables = vec![
             TableMeta {
                 name: "Affiliates".to_string(),
+                username: "crazyguy".to_string(),
+                db_name: "BookerDB".to_string(),
+                path_tsv: "Affiliates.tsv".to_string(),
+                path_bin: "Affiliates.bin".to_string(),
                 primary_key: vec!["AffID".to_string()],
                 foreign_key: vec![],
                 reference_table: None,
                 reference_attr: None,
-                path_tsv: "Affiliates.tsv".to_string(),
-                path_bin: "Affiliates.bin".to_string(),
                 attr_offset_ranges: vec![vec![0, 1], vec![1, 5], vec![5, 55], vec![55, 95], vec![95, 115]],
                 row_length: 115,
                 // ignore attrs checking
@@ -1477,12 +1481,14 @@ mod tests {
             },
             TableMeta {
                 name: "Hotels".to_string(),
+                username: "crazyguy".to_string(),
+                db_name: "BookerDB".to_string(),
+                path_tsv: "Hotels.tsv".to_string(),
+                path_bin: "Hotels.bin".to_string(),
                 primary_key: vec!["HotelID".to_string()],
                 foreign_key: vec![],
                 reference_table: None,
                 reference_attr: None,
-                path_tsv: "Hotels.tsv".to_string(),
-                path_bin: "Hotels.bin".to_string(),
                 attr_offset_ranges: vec![vec![0, 1], vec![1, 5], vec![5, 55], vec![55, 95], vec![95, 115]],
                 row_length: 115,
                 // ignore attrs checking
@@ -1507,13 +1513,15 @@ mod tests {
 
         for i in 0..tables.len() {
             assert_eq!(tables[i].name, ideal_tables[i].name);
+            assert_eq!(tables[i].username, ideal_tables[i].username);
+            assert_eq!(tables[i].db_name, ideal_tables[i].db_name);
+            assert_eq!(tables[i].path_tsv, ideal_tables[i].path_tsv);
+            assert_eq!(tables[i].path_bin, ideal_tables[i].path_bin);
             assert_eq!(tables[i].primary_key, ideal_tables[i].primary_key);
             assert_eq!(tables[i].foreign_key, ideal_tables[i].foreign_key);
             assert_eq!(tables[i].reference_table, ideal_tables[i].reference_table);
             assert_eq!(tables[i].reference_attr, ideal_tables[i].reference_attr);
             assert_eq!(tables[i].row_length, ideal_tables[i].row_length);
-            assert_eq!(tables[i].path_tsv, ideal_tables[i].path_tsv);
-            assert_eq!(tables[i].path_bin, ideal_tables[i].path_bin);
             assert_eq!(tables[i].attr_offset_ranges, ideal_tables[i].attr_offset_ranges);
         }
 

--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -1,369 +1,404 @@
+use crate::storage::diskinterface::{DiskError, TableMeta};
+
 use std::fmt;
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::Seek;
-use std::io::SeekFrom;
-use std::mem;
-
-#[derive(Debug)]
-pub enum IndexError {
-    OpenFileError,
-    CreateFileError,
-    BuildIntIndexTableError,
-    ReadIntIndexTableError,
-    BuildStringIndexTableError,
-    ReadStringIndexTableError,
-    WriteIndexError,
-    InsertValueMismatchIndex,
-}
-
-impl fmt::Display for IndexError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            IndexError::OpenFileError => write!(f, "cannot open file"),
-            IndexError::CreateFileError => write!(f, "cannot create file"),
-            IndexError::BuildIntIndexTableError => write!(f, "Build int index table error"),
-            IndexError::ReadIntIndexTableError => write!(f, "Read int index table error"),
-            IndexError::BuildStringIndexTableError => write!(f, "Build string index table error"),
-            IndexError::ReadStringIndexTableError => write!(f, "Read string index table error"),
-            IndexError::WriteIndexError => write!(f, "Write index table error"),
-            IndexError::InsertValueMismatchIndex => write!(f, "Type of the insert value mismatches index"),
-        }
-    }
-}
 
 pub struct Index {
     table_meta: TableMeta,
-    index_data: IndexData,
+    index_data: Vec<RowPair>,
 }
 
-/// meta data of raw table
-#[derive(Debug)]
-pub struct TableMeta {
-    table_name: String, // name of raw table
-    key_type: KeyType,  // type of primary key in raw table
-    key_offset: u32,    // byte position of first primary key in raw table
-    key_bytes: u32,     // bytes of primary key in raw table
-    row_bytes: u32,     // bytes of each row in raw table
-}
+// /// meta data of raw table
+// #[derive(Debug)]
+// pub struct TableMeta {
+//     table_name: String, // name of raw table
+//     key_type: KeyType,  // type of primary key in raw table
+//     key_offset: u32,    // byte position of first primary key in raw table
+//     key_bytes: u32,     // bytes of primary key in raw table
+//     row_bytes: u32,     // bytes of each row in raw table
+// }
 
-/// row and key value pair in which key type is int
-pub struct RowPairInt {
-    row: u32,
-    key_value: u32,
-}
+// /// row and key value pair in which key type is int
+// pub struct RowPairInt {
+//     row: u32,
+//     key_value: u32,
+// }
 
-impl RowPairInt {
-    fn new(pair: (u32, &str)) -> RowPairInt {
-        RowPairInt {
-            row: pair.0,
-            key_value: pair.1.parse::<u32>().unwrap(),
-        }
-    }
-}
+// impl RowPairInt {
+//     fn new(pair: (u32, &str)) -> RowPairInt {
+//         RowPairInt {
+//             row: pair.0,
+//             key_value: pair.1.parse::<u32>().unwrap(),
+//         }
+//     }
+// }
 
-/// row and key value pair in which key type is string
-pub struct RowPairString {
+// /// row and key value pair in which key type is string
+// pub struct RowPairString {
+//     row: u32,
+//     key_value: Vec<u8>,
+// }
+
+// impl RowPairString {
+//     fn new(pair: (u32, &str)) -> RowPairString {
+//         RowPairString {
+//             row: pair.0,
+//             key_value: pair.1.as_bytes().to_vec(),
+//         }
+//     }
+// }
+
+/// (row, key_value) pair
+pub struct RowPair {
     row: u32,
     key_value: Vec<u8>,
 }
 
-impl RowPairString {
-    fn new(pair: (u32, &str)) -> RowPairString {
-        RowPairString {
+impl RowPair {
+    fn new(pair: (u32, &Vec<u8>)) -> RowPair {
+        RowPair {
             row: pair.0,
-            key_value: pair.1.as_bytes().to_vec(),
+            key_value: pair.1.to_vec(),
         }
     }
 }
 
-#[allow(dead_code)]
-pub enum IndexData {
-    IndexInt(Vec<RowPairInt>),
-    IndexString(Vec<RowPairString>),
-    None,
-}
+// #[allow(dead_code)]
+// pub enum IndexData {
+//     IndexInt(Vec<RowPairInt>),
+//     IndexString(Vec<RowPairString>),
+//     None,
+// }
 
-#[derive(Debug, PartialEq)]
-pub enum KeyType {
-    Int,
-    String,
-}
+// #[derive(Debug, PartialEq)]
+// pub enum KeyType {
+//     Int,
+//     String,
+// }
 
 #[allow(dead_code)]
 impl Index {
     /// construct a new Index
-    pub fn new(table_meta: TableMeta) -> Result<Index, IndexError> {
+    pub fn new(table_meta: TableMeta) -> Result<Index, DiskError> {
         Ok(Index {
             table_meta,
-            index_data: IndexData::None,
+            index_data: vec![],
         })
     }
 
-    /// create a new index data for Index
-    fn build_index(&mut self) -> Result<(), IndexError> {
-        self.index_data = match self.table_meta.key_type {
-            KeyType::Int => IndexData::IndexInt(self.build_int_index_table()?),
-            KeyType::String => IndexData::IndexString(self.build_string_index_table()?),
-        };
-        Ok(())
-    }
+    // build index from table bin file
+    // fn build_from_file(&mut self, file_base_path: Option<&str>) -> Result<(), IndexError> {
+    //     // determine file base path
+    //     let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
 
-    /// Write index to storage
-    pub fn write_index_table(&mut self) -> Result<(), IndexError> {
-        match &self.index_data {
-            IndexData::IndexInt(index_int) => self.write_int_index_table(&index_int),
-            IndexData::IndexString(index_string) => self.write_string_index_table(&index_string),
-            IndexData::None => Ok(()), // should not happen
-        }
-    }
+    //     // perform storage check toward table level
+    //     DiskInterface::storage_hierarchy_check(base_path, Some(username), Some(db_name), Some(table_name)).map_err(|e| e)?;
 
-    /// Read index from storage
-    pub fn read_index_table(&mut self) -> Result<(), IndexError> {
-        match self.table_meta.key_type {
-            KeyType::Int => self.read_int_index_table(),
-            KeyType::String => self.read_string_index_table(),
-        }
-    }
+    //     // load current tables from `tables.json`
+    //     let tables_json_path = format!("{}/{}/{}/{}", base_path, username, db_name, "tables.json");
+    //     let tables_file = fs::File::open(&tables_json_path)?;
+    //     let tables_json: TablesJson = serde_json::from_reader(tables_file)?;
 
-    /// insert a row-key pair into the index
-    pub fn insert_index_table(&mut self, value_pair: (u32, &str)) -> Result<(), IndexError> {
-        let key_type = match value_pair.1.parse::<u32>() {
-            Ok(_) => KeyType::Int,
-            Err(_) => KeyType::String,
-        };
+    //     // locate meta of target table
+    //     let idx_target = tables_json
+    //         .tables
+    //         .iter()
+    //         .position(|table_meta| &table_meta.name == table_name);
 
-        match self.index_data {
-            IndexData::IndexInt(ref mut index_int) => match key_type {
-                KeyType::Int => {
-                    let pair = RowPairInt::new(value_pair);
-                    Index::insert_int_index_table(pair, index_int)
-                }
-                KeyType::String => Err(IndexError::InsertValueMismatchIndex),
-            },
-            IndexData::IndexString(ref mut index_string) => match key_type {
-                KeyType::Int => Err(IndexError::InsertValueMismatchIndex),
-                KeyType::String => {
-                    let pair = RowPairString::new(value_pair);
-                    Index::insert_string_index_table(pair, index_string)
-                }
-            },
-            IndexData::None => Ok(()), // should not happen
-        }
-    }
+    //     let table_meta_target: &TableMeta = match idx_target {
+    //         Some(idx) => &tables_json.tables[idx],
+    //         None => return Err(FileError::TableNotExists),
+    //     };
 
-    /// build index table with raw table in which key type is int
-    fn build_int_index_table(&self) -> Result<(Vec<RowPairInt>), IndexError> {
-        let mut index_arr = vec![];
-        let mut row = 0;
-        let table_meta = &self.table_meta;
-        let bytes_to_slide = table_meta.row_bytes - table_meta.key_bytes;
-        let table_name = table_meta.table_name.clone();
-        let mut file = File::open(table_name).map_err(|_| IndexError::OpenFileError)?;
-        file.seek(SeekFrom::Start(table_meta.key_offset as u64))
-            .map_err(|_| IndexError::BuildIntIndexTableError)?;
-        let mut buffer = [0; 4];
-        loop {
-            let _bytes_read = match file.read(&mut buffer) {
-                Ok(0) => break, // end-of-file
-                Ok(_) => {
-                    unsafe {
-                        let temp = mem::transmute::<[u8; 4], u32>(buffer);
-                        let index_content = RowPairInt {
-                            row: row,
-                            key_value: temp,
-                        };
-                        index_arr.push(index_content);
-                    }
-                    file.seek(SeekFrom::Current(bytes_to_slide as i64))
-                        .map_err(|_| IndexError::BuildIntIndexTableError)?;
-                    row = row + 1;
-                }
-                Err(_) => {
-                    return Err(IndexError::BuildIntIndexTableError);
-                }
-            };
-        }
+    //     // load corresponding chunk of bytes from table bin
+    //     let table_bin_path = format!("{}/{}/{}/{}.bin", base_path, username, db_name, table_name);
+    //     let table_bin_file = fs::File::open(&table_bin_path)?;
+    //     let mut buffered = BufReader::new(table_bin_file);
 
-        index_arr.sort_unstable_by(|a, b| a.key_value.cmp(&b.key_value));
-        Ok(index_arr)
-    }
+    //     let mut chunk_bytes = vec![];
+    //     buffered.seek(SeekFrom::Start((row_range[0] * table_meta_target.row_length) as u64))?;
+    //     let mut raw = buffered.take(((row_range[1] - row_range[0]) * table_meta_target.row_length) as u64);
+    //     raw.read_to_end(&mut chunk_bytes)?;
 
-    /// write index table into index file
-    fn write_int_index_table(&self, index_arr: &Vec<RowPairInt>) -> Result<(), IndexError> {
-        let table_index_name = format!("{}.index", self.table_meta.table_name);
-        let mut file_write = File::create(table_index_name).map_err(|_| IndexError::CreateFileError)?;
-        for i in 0..index_arr.len() {
-            let row_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].row) };
-            file_write.write(&row_temp).map_err(|_| IndexError::WriteIndexError)?;
-            let key_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].key_value) };
-            file_write.write(&key_temp).map_err(|_| IndexError::WriteIndexError)?;
-        }
-        Ok(())
-    }
+    //     if chunk_bytes.len() != ((row_range[1] - row_range[0]) * table_meta_target.row_length) as usize {
+    //         return Err(FileError::RangeExceedLatestRecord);
+    //     }
 
-    /// read index table from index file
-    fn read_int_index_table(&mut self) -> Result<(), IndexError> {
-        let mut index_arr = vec![];
-        let table_index_name = format!("{}.index", self.table_meta.table_name);
-        let mut file = File::open(table_index_name).map_err(|_| IndexError::OpenFileError)?;
-        let mut buffer_row = [0; 4];
-        let mut buffer_key = [0; 4];
-        loop {
-            let _bytes_read = match file.read(&mut buffer_row) {
-                Ok(0) => break, // end-of-file
-                Ok(_) => unsafe {
-                    let temp_row = mem::transmute::<[u8; 4], u32>(buffer_row);
-                    file.read(&mut buffer_key)
-                        .map_err(|_| IndexError::ReadIntIndexTableError)?;
-                    let temp_key = mem::transmute::<[u8; 4], u32>(buffer_key);
-                    let index_content = RowPairInt {
-                        row: temp_row,
-                        key_value: temp_key,
-                    };
-                    index_arr.push(index_content);
-                },
-                Err(_) => {
-                    return Err(IndexError::ReadIntIndexTableError);
-                }
-            };
-        }
-        self.index_data = IndexData::IndexInt(index_arr);
-        Ok(())
-    }
+    //     // parse chunk of bytes to vector of rows
+    //     let mut rows: Vec<Row> = vec![];
+    //     for row_bytes in chunk_bytes.chunks(table_meta_target.row_length as usize) {
+    //         if row_bytes[0] == 0 as u8 {
+    //             return Err(FileError::RangeContainsDeletedRecord);
+    //         }
+    //         rows.push(BytesCoder::bytes_to_row(&table_meta_target, &row_bytes.to_vec())?);
+    //     }
 
-    /// insert into index table in which primary key type is int
-    fn insert_int_index_table(insert_value: RowPairInt, index_arr: &mut Vec<RowPairInt>) -> Result<(), IndexError> {
-        if index_arr.is_empty() {
-            index_arr.push(insert_value);
-        } else {
-            let mut target = 0;
-            for i in 0..index_arr.len() {
-                if insert_value.key_value <= index_arr[i].key_value {
-                    target = i;
-                    break;
-                }
-            }
-            if target == 0 {
-                index_arr.insert(target, insert_value);
-            } else {
-                index_arr.insert(target - 1, insert_value);
-            }
-        }
-        Ok(())
-    }
+    //     Ok(rows)
+    // }
 
-    fn build_string_index_table(&self) -> Result<(Vec<RowPairString>), IndexError> {
-        let mut index_arr = vec![];
-        let mut row = 0;
-        let table_meta = &self.table_meta;
-        let bytes_to_slide = table_meta.row_bytes - table_meta.key_bytes;
-        let table_name = table_meta.table_name.clone();
-        let mut file = File::open(table_name).map_err(|_| IndexError::OpenFileError)?;
-        file.seek(SeekFrom::Start(table_meta.key_offset as u64))
-            .map_err(|_| IndexError::BuildStringIndexTableError)?;
-        let mut buffer = vec![0; table_meta.key_bytes as usize];
-        loop {
-            let _bytes_read = match file.read(&mut buffer) {
-                Ok(0) => break, // end-of-file
-                Ok(_) => {
-                    let index_content = RowPairString {
-                        row: row,
-                        key_value: buffer.clone(),
-                    };
-                    index_arr.push(index_content);
-                    file.seek(SeekFrom::Current(bytes_to_slide as i64))
-                        .map_err(|_| IndexError::BuildStringIndexTableError)?;
-                    row = row + 1;
-                }
-                Err(_) => {
-                    return Err(IndexError::BuildStringIndexTableError);
-                }
-            };
-        }
+    // /// create a new index data for Index
+    // fn build_index(&mut self) -> Result<(), IndexError> {
+    //     self.index_data = match self.table_meta.key_type {
+    //         KeyType::Int => IndexData::IndexInt(self.build_int_index_table()?),
+    //         KeyType::String => IndexData::IndexString(self.build_string_index_table()?),
+    //     };
+    //     Ok(())
+    // }
 
-        index_arr.sort_unstable_by(|a, b| a.key_value.cmp(&b.key_value));
-        Ok(index_arr)
-    }
+    // /// Write index to storage
+    // pub fn write_index_table(&mut self) -> Result<(), IndexError> {
+    //     match &self.index_data {
+    //         IndexData::IndexInt(index_int) => self.write_int_index_table(&index_int),
+    //         IndexData::IndexString(index_string) => self.write_string_index_table(&index_string),
+    //         IndexData::None => Ok(()), // should not happen
+    //     }
+    // }
 
-    fn write_string_index_table(&self, index_arr: &Vec<RowPairString>) -> Result<(), IndexError> {
-        let table_index_name = format!("{}.index", self.table_meta.table_name);
-        let mut file_write = File::create(table_index_name).map_err(|_| IndexError::CreateFileError)?;
-        for i in 0..index_arr.len() {
-            let row_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].row) };
-            file_write.write(&row_temp).map_err(|_| IndexError::WriteIndexError)?;
-            file_write
-                .write(&index_arr[i].key_value)
-                .map_err(|_| IndexError::WriteIndexError)?;
-        }
-        Ok(())
-    }
+    // /// Read index from storage
+    // pub fn read_index_table(&mut self) -> Result<(), IndexError> {
+    //     match self.table_meta.key_type {
+    //         KeyType::Int => self.read_int_index_table(),
+    //         KeyType::String => self.read_string_index_table(),
+    //     }
+    // }
 
-    fn read_string_index_table(&mut self) -> Result<(), IndexError> {
-        let mut index_arr = vec![];
-        let table_index_name = format!("{}.index", self.table_meta.table_name);
-        let mut file = File::open(table_index_name).map_err(|_| IndexError::OpenFileError)?;
-        let mut buffer_row = [0; 4];
-        let mut buffer_key = vec![0; self.table_meta.key_bytes as usize];
-        loop {
-            let _bytes_read = match file.read(&mut buffer_row) {
-                Ok(0) => break, // end-of-file
-                Ok(_) => unsafe {
-                    let temp_row = mem::transmute::<[u8; 4], u32>(buffer_row);
-                    file.read(&mut buffer_key)
-                        .map_err(|_| IndexError::ReadStringIndexTableError)?;
-                    let index_content = RowPairString {
-                        row: temp_row,
-                        key_value: buffer_key.clone(),
-                    };
-                    index_arr.push(index_content);
-                },
-                Err(_) => {
-                    return Err(IndexError::ReadStringIndexTableError);
-                }
-            };
-        }
-        self.index_data = IndexData::IndexString(index_arr);
-        Ok(())
-    }
+    // /// insert a row-key pair into the index
+    // pub fn insert_index_table(&mut self, value_pair: (u32, &str)) -> Result<(), IndexError> {
+    //     let key_type = match value_pair.1.parse::<u32>() {
+    //         Ok(_) => KeyType::Int,
+    //         Err(_) => KeyType::String,
+    //     };
 
-    fn insert_string_index_table(
-        insert_value: RowPairString,
-        index_arr: &mut Vec<RowPairString>,
-    ) -> Result<(), IndexError> {
-        if index_arr.is_empty() {
-            index_arr.push(insert_value);
-        } else {
-            let mut target = 0;
-            for i in 0..index_arr.len() {
-                if insert_value.key_value <= index_arr[i].key_value {
-                    target = i;
-                    break;
-                }
-            }
-            if target == 0 {
-                index_arr.insert(target, insert_value);
-            } else {
-                index_arr.insert(target - 1, insert_value);
-            }
-        }
-        Ok(())
-    }
+    //     match self.index_data {
+    //         IndexData::IndexInt(ref mut index_int) => match key_type {
+    //             KeyType::Int => {
+    //                 let pair = RowPairInt::new(value_pair);
+    //                 Index::insert_int_index_table(pair, index_int)
+    //             }
+    //             KeyType::String => Err(IndexError::InsertValueMismatchIndex),
+    //         },
+    //         IndexData::IndexString(ref mut index_string) => match key_type {
+    //             KeyType::Int => Err(IndexError::InsertValueMismatchIndex),
+    //             KeyType::String => {
+    //                 let pair = RowPairString::new(value_pair);
+    //                 Index::insert_string_index_table(pair, index_string)
+    //             }
+    //         },
+    //         IndexData::None => Ok(()), // should not happen
+    //     }
+    // }
+
+    // /// build index table with raw table in which key type is int
+    // fn build_int_index_table(&self) -> Result<(Vec<RowPairInt>), IndexError> {
+    //     let mut index_arr = vec![];
+    //     let mut row = 0;
+    //     let table_meta = &self.table_meta;
+    //     let bytes_to_slide = table_meta.row_bytes - table_meta.key_bytes;
+    //     let table_name = table_meta.table_name.clone();
+    //     let mut file = File::open(table_name).map_err(|_| IndexError::OpenFileError)?;
+    //     file.seek(SeekFrom::Start(table_meta.key_offset as u64))
+    //         .map_err(|_| IndexError::BuildIntIndexTableError)?;
+    //     let mut buffer = [0; 4];
+    //     loop {
+    //         let _bytes_read = match file.read(&mut buffer) {
+    //             Ok(0) => break, // end-of-file
+    //             Ok(_) => {
+    //                 unsafe {
+    //                     let temp = mem::transmute::<[u8; 4], u32>(buffer);
+    //                     let index_content = RowPairInt {
+    //                         row: row,
+    //                         key_value: temp,
+    //                     };
+    //                     index_arr.push(index_content);
+    //                 }
+    //                 file.seek(SeekFrom::Current(bytes_to_slide as i64))
+    //                     .map_err(|_| IndexError::BuildIntIndexTableError)?;
+    //                 row = row + 1;
+    //             }
+    //             Err(_) => {
+    //                 return Err(IndexError::BuildIntIndexTableError);
+    //             }
+    //         };
+    //     }
+
+    //     index_arr.sort_unstable_by(|a, b| a.key_value.cmp(&b.key_value));
+    //     Ok(index_arr)
+    // }
+
+    // /// write index table into index file
+    // fn write_int_index_table(&self, index_arr: &Vec<RowPairInt>) -> Result<(), IndexError> {
+    //     let table_index_name = format!("{}.index", self.table_meta.table_name);
+    //     let mut file_write = File::create(table_index_name).map_err(|_| IndexError::CreateFileError)?;
+    //     for i in 0..index_arr.len() {
+    //         let row_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].row) };
+    //         file_write.write(&row_temp).map_err(|_| IndexError::WriteIndexError)?;
+    //         let key_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].key_value) };
+    //         file_write.write(&key_temp).map_err(|_| IndexError::WriteIndexError)?;
+    //     }
+    //     Ok(())
+    // }
+
+    // /// read index table from index file
+    // fn read_int_index_table(&mut self) -> Result<(), IndexError> {
+    //     let mut index_arr = vec![];
+    //     let table_index_name = format!("{}.index", self.table_meta.table_name);
+    //     let mut file = File::open(table_index_name).map_err(|_| IndexError::OpenFileError)?;
+    //     let mut buffer_row = [0; 4];
+    //     let mut buffer_key = [0; 4];
+    //     loop {
+    //         let _bytes_read = match file.read(&mut buffer_row) {
+    //             Ok(0) => break, // end-of-file
+    //             Ok(_) => unsafe {
+    //                 let temp_row = mem::transmute::<[u8; 4], u32>(buffer_row);
+    //                 file.read(&mut buffer_key)
+    //                     .map_err(|_| IndexError::ReadIntIndexTableError)?;
+    //                 let temp_key = mem::transmute::<[u8; 4], u32>(buffer_key);
+    //                 let index_content = RowPairInt {
+    //                     row: temp_row,
+    //                     key_value: temp_key,
+    //                 };
+    //                 index_arr.push(index_content);
+    //             },
+    //             Err(_) => {
+    //                 return Err(IndexError::ReadIntIndexTableError);
+    //             }
+    //         };
+    //     }
+    //     self.index_data = IndexData::IndexInt(index_arr);
+    //     Ok(())
+    // }
+
+    // /// insert into index table in which primary key type is int
+    // fn insert_int_index_table(insert_value: RowPairInt, index_arr: &mut Vec<RowPairInt>) -> Result<(), IndexError> {
+    //     if index_arr.is_empty() {
+    //         index_arr.push(insert_value);
+    //     } else {
+    //         let mut target = 0;
+    //         for i in 0..index_arr.len() {
+    //             if insert_value.key_value <= index_arr[i].key_value {
+    //                 target = i;
+    //                 break;
+    //             }
+    //         }
+    //         if target == 0 {
+    //             index_arr.insert(target, insert_value);
+    //         } else {
+    //             index_arr.insert(target - 1, insert_value);
+    //         }
+    //     }
+    //     Ok(())
+    // }
+
+    // fn build_string_index_table(&self) -> Result<(Vec<RowPairString>), IndexError> {
+    //     let mut index_arr = vec![];
+    //     let mut row = 0;
+    //     let table_meta = &self.table_meta;
+    //     let bytes_to_slide = table_meta.row_bytes - table_meta.key_bytes;
+    //     let table_name = table_meta.table_name.clone();
+    //     let mut file = File::open(table_name).map_err(|_| IndexError::OpenFileError)?;
+    //     file.seek(SeekFrom::Start(table_meta.key_offset as u64))
+    //         .map_err(|_| IndexError::BuildStringIndexTableError)?;
+    //     let mut buffer = vec![0; table_meta.key_bytes as usize];
+    //     loop {
+    //         let _bytes_read = match file.read(&mut buffer) {
+    //             Ok(0) => break, // end-of-file
+    //             Ok(_) => {
+    //                 let index_content = RowPairString {
+    //                     row: row,
+    //                     key_value: buffer.clone(),
+    //                 };
+    //                 index_arr.push(index_content);
+    //                 file.seek(SeekFrom::Current(bytes_to_slide as i64))
+    //                     .map_err(|_| IndexError::BuildStringIndexTableError)?;
+    //                 row = row + 1;
+    //             }
+    //             Err(_) => {
+    //                 return Err(IndexError::BuildStringIndexTableError);
+    //             }
+    //         };
+    //     }
+
+    //     index_arr.sort_unstable_by(|a, b| a.key_value.cmp(&b.key_value));
+    //     Ok(index_arr)
+    // }
+
+    // fn write_string_index_table(&self, index_arr: &Vec<RowPairString>) -> Result<(), IndexError> {
+    //     let table_index_name = format!("{}.index", self.table_meta.table_name);
+    //     let mut file_write = File::create(table_index_name).map_err(|_| IndexError::CreateFileError)?;
+    //     for i in 0..index_arr.len() {
+    //         let row_temp = unsafe { mem::transmute::<u32, [u8; 4]>(index_arr[i].row) };
+    //         file_write.write(&row_temp).map_err(|_| IndexError::WriteIndexError)?;
+    //         file_write
+    //             .write(&index_arr[i].key_value)
+    //             .map_err(|_| IndexError::WriteIndexError)?;
+    //     }
+    //     Ok(())
+    // }
+
+    // fn read_string_index_table(&mut self) -> Result<(), IndexError> {
+    //     let mut index_arr = vec![];
+    //     let table_index_name = format!("{}.index", self.table_meta.table_name);
+    //     let mut file = File::open(table_index_name).map_err(|_| IndexError::OpenFileError)?;
+    //     let mut buffer_row = [0; 4];
+    //     let mut buffer_key = vec![0; self.table_meta.key_bytes as usize];
+    //     loop {
+    //         let _bytes_read = match file.read(&mut buffer_row) {
+    //             Ok(0) => break, // end-of-file
+    //             Ok(_) => unsafe {
+    //                 let temp_row = mem::transmute::<[u8; 4], u32>(buffer_row);
+    //                 file.read(&mut buffer_key)
+    //                     .map_err(|_| IndexError::ReadStringIndexTableError)?;
+    //                 let index_content = RowPairString {
+    //                     row: temp_row,
+    //                     key_value: buffer_key.clone(),
+    //                 };
+    //                 index_arr.push(index_content);
+    //             },
+    //             Err(_) => {
+    //                 return Err(IndexError::ReadStringIndexTableError);
+    //             }
+    //         };
+    //     }
+    //     self.index_data = IndexData::IndexString(index_arr);
+    //     Ok(())
+    // }
+
+    // fn insert_string_index_table(
+    //     insert_value: RowPairString,
+    //     index_arr: &mut Vec<RowPairString>,
+    // ) -> Result<(), IndexError> {
+    //     if index_arr.is_empty() {
+    //         index_arr.push(insert_value);
+    //     } else {
+    //         let mut target = 0;
+    //         for i in 0..index_arr.len() {
+    //             if insert_value.key_value <= index_arr[i].key_value {
+    //                 target = i;
+    //                 break;
+    //             }
+    //         }
+    //         if target == 0 {
+    //             index_arr.insert(target, insert_value);
+    //         } else {
+    //             index_arr.insert(target - 1, insert_value);
+    //         }
+    //     }
+    //     Ok(())
+    // }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    pub fn test_construct_index() {
-        let table_meta = TableMeta {
-            table_name: String::from("test_data/1.in"),
-            key_type: KeyType::Int,
-            key_offset: 0,
-            key_bytes: 4,
-            row_bytes: 4,
-        };
-        let mut index = Index::new(table_meta).unwrap();
-        index.write_index_table().unwrap();
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     #[test]
+//     pub fn test_construct_index() {
+//         let table_meta = TableMeta {
+//             table_name: String::from("test_data/1.in"),
+//             key_type: KeyType::Int,
+//             key_offset: 0,
+//             key_bytes: 4,
+//             row_bytes: 4,
+//         };
+//         let mut index = Index::new(table_meta).unwrap();
+//         index.write_index_table().unwrap();
+//     }
+// }

--- a/src/storage/index.rs
+++ b/src/storage/index.rs
@@ -37,7 +37,7 @@ impl RowPair {
 
 #[allow(dead_code)]
 impl Index {
-    /// construct a new Index
+    //// construct a new Index
     pub fn new(table_meta: TableMeta) -> Result<Index, DiskError> {
         Ok(Index {
             table_meta,
@@ -46,8 +46,8 @@ impl Index {
         })
     }
 
-    // build index from table bin file
-    fn build_from_bin(&mut self, file_base_path: Option<&str>) -> Result<(), DiskError> {
+    /// build index from table bin file
+    pub fn build_from_bin(&mut self, file_base_path: Option<&str>) -> Result<(), DiskError> {
         // determine file base path
         let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
 
@@ -95,8 +95,8 @@ impl Index {
         Ok(())
     }
 
-    // save(overwrite) index table into index file
-    fn save(&self, file_base_path: Option<&str>) -> Result<(), DiskError> {
+    /// save(overwrite) index table into index file
+    pub fn save(&self, file_base_path: Option<&str>) -> Result<(), DiskError> {
         // determine file base path
         let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
 
@@ -134,7 +134,7 @@ impl Index {
         Ok(())
     }
 
-    // Load index from storage
+    /// Load index from storage
     pub fn load(&mut self, file_base_path: Option<&str>) -> Result<(), DiskError> {
         // determine file base path
         let base_path = file_base_path.unwrap_or(dotenv!("FILE_BASE_PATH"));
@@ -187,7 +187,7 @@ impl Index {
         Ok(())
     }
 
-    // insert a row-key pair into the index
+    /// insert a row-key pair into the index
     pub fn insert(&mut self, row: &Row) -> Result<(), DiskError> {
         let new_row_pair = RowPair::new(
             self.num_rows.clone(),
@@ -212,7 +212,7 @@ impl Index {
         Ok(())
     }
 
-    // delete a row-key pair from the index
+    /// delete a row-key pair from the index
     pub fn delete(&mut self, row: &Row) -> Result<(), DiskError> {
         let key_val = BytesCoder::attr_to_bytes(
             &self.table_meta.attrs[&self.table_meta.primary_key[0]].datatype,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,5 @@
 pub mod bytescoder;
+pub mod diskinterface;
 pub mod file;
 pub mod index;
 pub mod io;


### PR DESCRIPTION
# Brief
* Rewrite `Index` build/load/save/insert/delete operations
* Build `DiskInterface`, which is the standard interface for accessing file and index

# Features:
1. Functions for file-related index operations:
    * `DiskInterface::build_index_from_table_bin`
    * `DiskInterface::load_index`
    * `DiskInterface::save_index`
2. Functions for memory-related index operations:
    * `Index::insert`
    * `Index::delete`
3. Implement `Index` ordering by *raw bytes* of primary key, rather than attr value with data type
    * RowPair: { row: u32, key_value: Vec\<u8\> }
4. Design test cases for the new functionalities
5. Merge `TableMeta` of `Index` and `File` into one at `DiskInterface`
6. Merge `FileError` and `IndexError` into `DiskError`
7. Extract storage info structs and hierarchy checking logics to `DiskInterface`

# Known Issues
* `Index` only support single-attr primary key currently